### PR TITLE
Using global imported os module

### DIFF
--- a/keras_efficientnets/efficientnet.py
+++ b/keras_efficientnets/efficientnet.py
@@ -17,6 +17,7 @@
   EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks.
   ICML'19, https://arxiv.org/abs/1905.11946
 """
+import os
 import math
 from typing import List
 

--- a/keras_efficientnets/efficientnet.py
+++ b/keras_efficientnets/efficientnet.py
@@ -1104,7 +1104,6 @@ def EfficientNetB7(input_shape=None,
 
 
 if __name__ == '__main__':
-    import os
     from keras.models import load_model
 
     model = EfficientNetB0(include_top=True)


### PR DESCRIPTION
Hello,

The os module is used in [EfficientNet](https://github.com/titu1994/keras-efficientnets/blob/8baf729f02688245fe4d59f8b624ae2c3a4f2628/keras_efficientnets/efficientnet.py#L296), but only has been imported in `__main__` section, I fixed this issue by moving the import instruction to the top level.  Please have a look. 

Thanks. 

